### PR TITLE
View info vanilla

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "btdc",
   "version": "1.0.0",
   "description": "Bicycle touring digital companion",
-  "main": "index.js",
   "scripts": {
     "postinstall": "cordova platform add android browser & true",
     "format": "jscs www/ -x -r inline; true",
@@ -10,19 +9,26 @@
     "build": "browserify www/js/app.js -t babelify -o www/js/bundle.js",
     "postbuild": "npm run doc",
     "prestart": "npm run build",
-    "start": "cordova run android",
-    "test": "mocha --compilers js:babel/register --recursive"
+    "prestart:browser": "npm run prestart",
+    "prestart:android": "npm run prestart",
+    "start:browser": "cordova serve 8000",
+    "start:android": "cordova run android",
+    "start": "npm run start:android",
+    "test": "mocha --compilers js:babel/register --recursive",
+    "watch": "nodemon -e js,html,css --watch \"www\" --ignore \"www/js/bundle.js\" --exec \"npm run start:browser\"",
+    "livereload": "livereload \"platforms/browser/www/\"",
+    "dev": "parallelshell \"npm run watch\" \"npm run livereload\""
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/bikelomatic-complexity/client-demo.git"
+    "url": "git+https://github.com/bikelomatic-complexity/app.git"
   },
   "author": "",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/bikelomatic-complexity/client-demo/issues"
+    "url": "https://github.com/bikelomatic-complexity/app/issues"
   },
-  "homepage": "https://github.com/bikelomatic-complexity/client-demo#readme",
+  "homepage": "https://github.com/bikelomatic-complexity/app#readme",
   "dependencies": {
     "leaflet": "^0.7.5",
     "react": "^0.14.0",
@@ -42,7 +48,10 @@
     "cordova": "^5.3.3",
     "esdoc": "^0.4.1",
     "jscs": "^2.3.4",
+    "livereload": "^0.4.0",
     "mocha": "^2.3.4",
+    "nodemon": "^1.8.1",
+    "parallelshell": "^2.0.0",
     "react-addons-test-utils": "^0.14.2",
     "redux-devtools": "^2.1.5",
     "skin-deep": "^0.13.0"

--- a/test/point-card-tests.js
+++ b/test/point-card-tests.js
@@ -17,48 +17,38 @@ import { SamplePoints } from './mock-data';
 // instance is the react component
 let vdom, instance, sample;
 
-beforeEach(() => {
-  sample = SamplePoints[0];
-  const tree = sd.shallowRender(
-    <PointCard
-      point={sample}
-      show={true}
-    />
-  );
-
-  instance = tree.getMountedInstance();
-  vdom = tree.getRenderOutput();
-});
-
 describe('PointCard', () => {
 
-  describe('minimized', () => {
+  describe('peeked', () => {
+
+    beforeEach(() => {
+      sample = SamplePoints[0];
+      const tree = sd.shallowRender(
+        <PointCard
+          point={sample}
+          show={'peek'}
+        />
+      );
+
+      instance = tree.getMountedInstance();
+      vdom = tree.getRenderOutput();
+    });
 
     describe('render', () => {
-      let cardComponent;
-      beforeEach(() => {
-        cardComponent = vdom.props.children;
-      });
 
       it('should have an id ', () => {
-        cardComponent.props.id.should.be.equal( "mdl-map-card" );
+        vdom.props.id.should.be.equal( "mdl-map-card" );
       });
 
       it('should have a title', () => {
-        const cardTitle = cardComponent.props.children[0];
+        const cardTitle = vdom.props.children[0];
         cardTitle.props.children.should.be.equal(sample.name);
       });
 
       it('should have a description', () => {
-        const cardDetails = cardComponent.props.children[1];
+        const cardDetails = vdom.props.children[1];
         const cardDescription = cardDetails.props.children[0];
         cardDescription.should.be.equal(sample.description);
-      });
-    });
-
-    describe('state', () => {
-      it('should start not full screen', () => {
-          instance.state.fullScreen.should.not.be.true;
       });
     });
 
@@ -67,34 +57,34 @@ describe('PointCard', () => {
   describe('full screen', () => {
 
     beforeEach(() => {
-      instance.setState({fullScreen:true});
+      sample = SamplePoints[0];
+      const tree = sd.shallowRender(
+        <PointCard
+          point={sample}
+          show={'full'}
+        />
+      );
+
+      instance = tree.getMountedInstance();
+      vdom = tree.getRenderOutput();
     });
 
     describe('render', () => {
-      let cardComponent;
-      beforeEach(() => {
-        cardComponent = vdom.props.children;
-      });
 
       it('should have an id ', () => {
-        cardComponent.props.id.should.be.equal( "mdl-map-card" );
+        vdom.props.id.should.be.equal( "mdl-map-card" );
       });
 
       it('should have a title', () => {
-        const cardTitle = cardComponent.props.children[0];
+        const cardTitle = vdom.props.children[0];
         cardTitle.props.children.should.be.equal(sample.name);
       });
 
       it('should have a description', () => {
-        const cardDetails = cardComponent.props.children[1];
-        const cardDescription = cardDetails.props.children[0];
-        cardDescription.should.be.equal(sample.description);
-      });
-    });
-
-    describe('state', () => {
-      it('should be full screen', () => {
-          instance.state.fullScreen.should.be.true;
+        const cardDetailsDiv = vdom.props.children[1];
+        const cardDescription = cardDetailsDiv.props.children[0];
+        const cardDescriptionText = cardDescription.props.children[1];
+        cardDescriptionText.should.be.equal(sample.description);
       });
     });
 

--- a/www/js/actions/actions.js
+++ b/www/js/actions/actions.js
@@ -1,5 +1,7 @@
 /* Action Types */
 export const SELECT_MARKER = 'SELECT_MARKER';
+export const PEEK_MARKER = 'PEEK_MARKER';
+export const FULLSCREEN_MARKER = 'FULLSCREEN_MARKER';
 export const DESELECT_MARKER = 'DESELECT_MARKER';
 
 /* Action Creators */
@@ -7,6 +9,18 @@ export function selectMarker(marker) {
   return {
     type: SELECT_MARKER,
     marker
+  }
+}
+
+export function peekMarker(marker) {
+  return {
+    type: PEEK_MARKER,
+  }
+}
+
+export function fullscreenMarker() {
+  return {
+    type: FULLSCREEN_MARKER
   }
 }
 

--- a/www/js/components/hammer-point-card.js
+++ b/www/js/components/hammer-point-card.js
@@ -1,0 +1,78 @@
+import React, {Component} from 'react';
+import Hammer from 'react-hammerjs';
+
+// import redux components
+import { connect } from 'react-redux';
+import { fullscreenMarker, peekMarker, deselectMarker } from '../actions/actions';
+
+// import the PointCard
+import PointCard from './point-card';
+
+// export class for testing (use default export in application)
+export class HammerPointCard extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      heightOffset: 0,
+      changeScreen: false
+    };
+  }
+
+  handleSwipe(e) {
+    const { dispatch } = this.props;
+    const pointDetails = document.getElementById('point-details');
+    /* if we are at the top of the card, pulling down should shrink the card */
+    if (this.props.show == "full") {
+      // in full screen
+      // because hammer onPanStart doesn't work, just check if that time of the action was within 0.15s
+      if ((pointDetails.scrollTop == 0) && (e.isFirst || e.deltaTime < 150)) {
+        // you can change the screen state since you're at the top
+        this.setState({changeScreen: true});
+      }
+      if ((pointDetails.scrollTop == 0) && this.state.changeScreen) {
+        // at the top of the details
+        this.setState({heightOffset: e.deltaY});
+      }
+      if (e.target.classList.contains("mdl-card__title") || e.target.classList.contains("mdl-card__title-text")) {
+        // at the top of the details
+        this.setState({heightOffset: e.deltaY});
+        this.setState({changeScreen: true});
+      }
+    } else {
+      // in peek screen
+      this.setState({changeScreen: true});
+      this.setState({heightOffset: e.deltaY});
+    }
+
+    /* Change the screen size (to full, peek, or hide) */
+    if (e.isFinal && this.state.changeScreen) {
+      this.setState({heightOffset: 0, changeScreen: false});
+      if (e.deltaY < -120) {
+        dispatch(fullscreenMarker())
+      } else if (e.deltaY > 120){
+        if (this.props.show == "full") {
+          dispatch(peekMarker())
+        } else {
+          dispatch(deselectMarker());
+        }
+      }
+    }
+
+  }
+
+  render() {
+
+    return (
+      <Hammer vertical={true} onPanStart={this.handleSwipe.bind(this)} onPan={this.handleSwipe.bind(this)}>
+        <PointCard
+          point={this.props.point}
+          show={this.props.show}
+          heightOffset={this.state.heightOffset}
+          changeScreen={this.state.changeScreen}
+        />
+      </Hammer>
+    );
+  }
+}
+
+export default connect()(HammerPointCard);

--- a/www/js/components/main-page.js
+++ b/www/js/components/main-page.js
@@ -6,7 +6,7 @@ import MyMap from './my-map';
 // import redux components
 import { connect } from 'react-redux';
 
-import PointCard from './point-card';
+import HammerPointCard from './hammer-point-card';
 
 class MainPage extends Component {
   constructor(props) {
@@ -32,7 +32,7 @@ class MainPage extends Component {
             </Navigation>
           </Drawer>
           <MyMap services={this.props.services}/>
-          <PointCard point={selectedPoint} show={marker.showCard}/>
+          <HammerPointCard point={selectedPoint} show={marker.showPointCard}/>
         </Layout>
       </div>
     );

--- a/www/js/components/point-card.js
+++ b/www/js/components/point-card.js
@@ -1,69 +1,16 @@
 import React, {Component} from 'react';
 import { Card, CardTitle, CardActions, IconButton, CardText, CardMenu, Button } from 'react-mdl';
-import Hammer from 'react-hammerjs';
 import HoursTable from './hours-table';
 
 // import redux components
 import { connect } from 'react-redux';
-import { deselectMarker } from '../actions/actions';
+import { peekMarker, fullscreenMarker, deselectMarker } from '../actions/actions';
 
 const dayMap = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
 
 // export class for testing (use default export in application)
 export class PointCard extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      fullScreen: false,
-      heightOffset: 0,
-      changeScreen: false
-    };
-  }
-  onSeeMore() {
-    this.setState({fullScreen:true});
-  }
-  onSeeLess() {
-    this.setState({fullScreen:false});
-  }
-  handleSwipe(e) {
-    const { dispatch } = this.props;
-    const pointDetails = document.getElementById('point-details');
-    /* if we are at the top of the card, pulling down should shrink the card */
-    if (this.state.fullScreen) {
-      // in full screen
-      // because hammer onPanStart doesn't work, just check if that time of the action was within 0.15s
-      if ((pointDetails.scrollTop == 0) && (e.isFirst || e.deltaTime < 150)) {
-        // you can change the screen state since you're at the top
-        this.setState({changeScreen: true});
-      }
-      if ((pointDetails.scrollTop == 0) && this.state.changeScreen) {
-        // at the top of the details
-        this.setState({heightOffset: e.deltaY});
-      }
-      if (e.target.classList.contains("mdl-card__title") || e.target.classList.contains("mdl-card__title-text")) {
-        // at the top of the details
-        this.setState({heightOffset: e.deltaY});
-        this.setState({changeScreen: true});
-      }
-    } else {
-      // in peek screen
-      this.setState({changeScreen: true});
-      this.setState({heightOffset: e.deltaY});
-    }
-    /* Change the screen size (to full, peek, or hide) */
-    if (e.isFinal && this.state.changeScreen) {
-      this.setState({heightOffset: 0, changeScreen: false});
-      if (e.deltaY < -120) {
-        this.setState({fullScreen:true});
-      } else if (e.deltaY > 120){
-        if (this.state.fullScreen) {
-          this.setState({fullScreen:false});
-        } else {
-          dispatch(deselectMarker());
-        }
-      }
-    }
-  }
+
   getDays(seasons) {
     let seasonDays = seasons[0].days;
     const date = (new Date());
@@ -77,28 +24,37 @@ export class PointCard extends Component {
     });
     return seasonDays;
   }
+
   render() {
-    let headerHeight = Math.max(55,  55 + this.state.heightOffset);
-    let smallHeight = 300 - this.state.heightOffset;
+    const { dispatch } = this.props;
+
+    let headerHeight = Math.max(55,  55 + this.props.heightOffset);
+    let smallHeight = 300 - this.props.heightOffset;
     let cardStyle = {
       width: '100%',
       position: 'fixed',
-      bottom: (this.props.show ? '0px' : '-300px'),
-      height: (this.state.fullScreen ? 'calc(100% - '+ headerHeight +'px)' : smallHeight +'px'),
-      transition: (this.state.heightOffset == 0 ? 'all 300ms ease' : ''),
+      bottom: ( (this.props.show=='peek' || this.props.show=='full') ? '0px' : '-300px'),
+      height: ( (this.props.show=='full') ? 'calc(100% - '+ headerHeight +'px)' : smallHeight +'px'),
+      transition: (this.props.heightOffset == 0 ? 'all 300ms ease' : ''),
       'zIndex':'8'
     }
+
     let cardTitleStyle = {
       color: '#fff',
       height: '176px',
       background: 'url(' + this.props.point.image + ') center / cover'
     }
+
     let seeButton = (
-      <Button colored onClick={this.onSeeMore.bind(this)}>See More</Button>
+      <Button colored onClick={() => {
+        dispatch(fullscreenMarker());
+      }}>See More</Button>
     );
-    if (this.state.fullScreen) {
+    if (this.props.show=='full') {
       seeButton = (
-        <Button colored onClick={this.onSeeLess.bind(this)}>See Less</Button>
+        <Button colored onClick={() => {
+          dispatch(peekMarker());
+        }}>See Less</Button>
       );
     }
 
@@ -126,7 +82,7 @@ export class PointCard extends Component {
     let seasonal = point.hours.length > 1;
 
     // large screen details
-    if (this.state.fullScreen) {
+    if (this.props.show=='full') {
       cardDetails = (
         <div id="point-details">
           <CardText> {point.description} {timeDetails}</CardText>
@@ -137,25 +93,26 @@ export class PointCard extends Component {
 
           <CardText> {point.phone} </CardText>
           <CardText> Visit <a href={point.website}>{point.website}</a> for more details </CardText>
-          { seasonal ? <br/> : <CardText> these hours are seasonal (call or check online for more information) </CardText> }
           <HoursTable hours={this.getDays(point.hours)}/>
+          { seasonal ? <br/> : <CardText> these hours are seasonal (call or check online for more information) </CardText> }
         </div>
       )
     }
 
     return (
-      <Hammer vertical={true} onPanStart={this.handleSwipe.bind(this)} onPan={this.handleSwipe.bind(this)}>
-        <Card id="mdl-map-card" shadow={5} style={cardStyle}>
-          <CardTitle style={cardTitleStyle}>{this.props.point.name}</CardTitle>
-          { cardDetails }
-          <CardActions border className="view-button">
-            {seeButton}
-          </CardActions>
-          <CardMenu style={{color: '#fff'}}>
-              <IconButton name="share" />
-          </CardMenu>
-        </Card>
-      </Hammer>
+      <Card id="mdl-map-card" shadow={5} style={cardStyle}>
+        <CardTitle style={cardTitleStyle}>{this.props.point.name}</CardTitle>
+        { cardDetails }
+        <CardActions border className="view-button">
+          { seeButton }
+          <Button colored onClick={() => {
+            dispatch(deselectMarker());
+          }}>Dismiss</Button>
+        </CardActions>
+        <CardMenu style={{color: '#fff'}}>
+            <IconButton name="share" />
+        </CardMenu>
+      </Card>
     );
   }
 }

--- a/www/js/reducers/reducer.js
+++ b/www/js/reducers/reducer.js
@@ -1,17 +1,27 @@
 import { combineReducers } from 'redux';
-import { SELECT_MARKER, DESELECT_MARKER } from '../actions/actions';
+import { SELECT_MARKER, PEEK_MARKER, DESELECT_MARKER, FULLSCREEN_MARKER } from '../actions/actions';
 
 function marker(state = {}, action) {
   switch (action.type) {
     case SELECT_MARKER:
       return {
         selectedMarker: action.marker,
-        showCard: true
+        showPointCard: 'peek'
+      };
+    case PEEK_MARKER:
+      return {
+        selectedMarker: state.selectedMarker,
+        showPointCard: 'peek'
       };
     case DESELECT_MARKER:
       return {
         selectedMarker: state.selectedMarker,
-        showCard: false
+        showPointCard: 'hide'
+      };
+    case FULLSCREEN_MARKER:
+      return {
+        selectedMarker: state.selectedMarker,
+        showPointCard: 'full'
       };
     default:
       return state;


### PR DESCRIPTION
![image](http://i.giphy.com/54rjZf0AayQaQ.gif)

This PR merges the de-hammerified PointCard into the View-Info branch.
It also merges the npm build tools (but you can ignore that).

__From the commit logs__
```
Logic from point-card is removed into hammer-point-card. The view logic
for point-card is separated from the touch logic handled in
hammer-point-card. hammer-point-card contains point-card, and passes
down important rendering information as props. They both dispatch new
events to set the PointCardShow to either 'peek', 'hide', or 'full'.

The new dispatch events allow any component to 'peek', 'hide', or set
to the view to 'full'. These events allow touch gestures (found in
    hammer-point-card) and buttons (found in point-card) to control the
logic that was otherwise passed-down and handled with this.state /
this.setState.

PointCardShow is no longer a boolean, and now fully describes the state
of the point card.

Add new Dissmiss button to allow quick dispatch of all events from touch
gestures and visible buttons.
```
__PointCard Peek__
![image](https://cloud.githubusercontent.com/assets/326557/11456421/66663cf0-9656-11e5-9303-5f6e168ddf45.png)

__PointCard Full__
![image](https://cloud.githubusercontent.com/assets/326557/11456424/8ae441c6-9656-11e5-8cc0-36a982e96af5.png)

__PointCard Hide__
![image](https://cloud.githubusercontent.com/assets/326557/11456428/a05848ea-9656-11e5-89d8-63a96784c59e.png)
