### PR TITLE
Fix middleware operation by fixing the devtools

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
     "postinstall:cordova": "cordova plugin add cordova-plugin-geolocation & cordova plugin add https://github.com/apache/cordova-plugin-file & cordova plugin add cordova-plugin-camera & cordova plugin add cordova-plugin-file-transfer & cordova plugin add https://github.com/hypery2k/cordova-sqlite-plugin & cordova plugin add cordova-plugin-network-information & cordova plugin add cordova-plugin-device",
     "format": "jscs www/ -x -r inline; true",
     "doc": "esdoc -c .esdoc.json",
-    "build": "browserify www/js/app.js -t babelify -o www/js/bundle.js",
-    "prestart:browser":"npm run build",
-    "prestart:android":"npm run build",
+    "build": "browserify www/js/app.js -t babelify -t envify -o www/js/bundle.js",
+    "prestart:browser": "npm run build",
+    "prestart:android": "npm run build",
     "start:browser": "cordova serve 8000",
     "start:android": "cordova run android",
     "start": "npm run start:android",
@@ -20,10 +20,8 @@
     "dev": "parallelshell \"npm run watch\" \"npm run livereload\"",
     "prebuild:apk": "npm run build",
     "build:apk": "cordova build android",
-
     "release:android": "cordova build android --release",
     "postrelease:android": "scripts/postrelease-android.js"
-
   },
   "repository": {
     "type": "git",
@@ -60,6 +58,7 @@
     "browserify": "^11.2.0",
     "chai": "^3.4.1",
     "cordova": "^5.3.3",
+    "envify": "^3.4.0",
     "esdoc": "^0.4.1",
     "jscs": "^2.3.4",
     "livereload": "^0.4.0",

--- a/www/js/store.js
+++ b/www/js/store.js
@@ -7,18 +7,30 @@ import reducers from './reducers'
 
 const reqMiddleware = [ thunk ];
 
-const devTools = window.devToolsExtension ? window.devToolsExtension : f => f;
+const devTools = typeof window === 'object' && typeof window.devToolsExtension !== 'undefined' ? window.devToolsExtension() : f => f;
 
 export default class StoreBuilder {
 
   constructor(extMiddleware) {
-    const allMiddleware = union(extMiddleware, reqMiddleware);
+    const all = [ ...reqMiddleware, ...extMiddleware ];
 
-    this.createStore = compose(applyMiddleware(...allMiddleware), devTools)(createStore);
+    if(process.env.NODE_ENV === 'development') {
+
+      this.finalCreateStore = compose(
+        applyMiddleware(...all),
+        devTools
+      )(createStore);
+
+    } else {
+
+      this.finalCreateStore = compose(
+        applyMiddleware(...all)
+      )(createStore);
+    }
   }
 
   build(initState = {}) {
-    return this.createStore(reducers, initState);
+    return this.finalCreateStore(reducers, initState);
   }
 
 }


### PR DESCRIPTION
This adds envify, so we can use process.env.NODE_ENV checks to disable devtools in production. Also, it fixes the bug that the devtools introduced into the compose() call in the store.