### PR TITLE
Ensure all incoming points on initial sync are added to the store

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "homepage": "https://github.com/bikelomatic-complexity/app#readme",
   "dependencies": {
     "blob-util": "^1.2.0",
+    "docuri": "^4.2.1",
     "immutable": "^3.7.6",
     "leaflet": "^0.7.7",
     "ngeohash": "^0.6.0",

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -52,7 +52,7 @@ document.addEventListener('deviceReady', () => {
   const network = new NetworkManager(store);
   network.monitor();
 
-  const sync = new Sync(local, store);
+  const sync = new Sync(local, gateway, store);
   sync.start();
 
   gateway.getPoints().then(points => {

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -36,6 +36,10 @@ class App extends React.Component {
   }
 }
 
+if(process.env.NODE_ENV === 'development') {
+  window.PouchDB = PouchDB;
+}
+
 const local = new PouchDB('stop-here-db');
 const gateway = new Gateway(local);
 


### PR DESCRIPTION
This fixes the bug where during sync, incoming points were not added to the store.
This fix does involve a hack... PouchDB doesn't return correct Blobs within change notifications. Right now, the real blobs must be fetched separately, which lags the map on startup.