### PR TITLE
Added 5 second timeout on getGeolocation, so android doesn't hang

### DIFF
--- a/www/js/components/point-map.js
+++ b/www/js/components/point-map.js
@@ -47,8 +47,11 @@ class PointMap extends Component {
         (err) => {
           console.error(err);
           dispatch(setMapLoading(false));
+        },
+        {
+          timeout: 5000
         }
-      )
+      );
     }
   }
 


### PR DESCRIPTION
If an Android user doesn't have location services turned on, right now the map hangs forever. This 5 second timeout ensures the user will be redirected to map eventually. We can do more to make this experience better. For instance, after a second of no geolocation response, we could display a "give up button".