### PR TITLE
Point PouchDB to the new AWS load balancer

### DIFF
--- a/www/js/config.js
+++ b/www/js/config.js
@@ -12,7 +12,8 @@ export const MBTILES_SERVER_ROOT = 'mbtiles';
 // may encounter errors doing that
 export const MBTILES_LOCAL_ROOT = 'cdvfile://localhost/temporary';
 
-export const COUCHDB_REMOTE_SERVER = 'http://52.3.58.165:5984/points';
+const BALANCER = 'OpsWorks-database-1500749100.us-east-1.elb.amazonaws.com';
+export const COUCHDB_REMOTE_SERVER = `http://${BALANCER}:5984/points`;
 
 /*
  * Returns a promise that resolves with an absolute path that can be used


### PR DESCRIPTION
We have a new load balancer on AWS. So, we're switching out the hard coded IP address to the load balancer DNS.