### PR TITLE
add location on initial map load for add point

### DIFF
--- a/www/js/components/add-point-location.js
+++ b/www/js/components/add-point-location.js
@@ -23,12 +23,15 @@ export class AddPointLocation extends Component {
   }
 
   updateLocationCoords(coords){
+    const { dispatch } = this.props;
     dispatch(setPointLocation(coords));
     this.forceUpdate();
   }
 
-  onLocationSelect() {
-    // switch the page
+  componentDidMount() {
+    console.log("MOUNTING");
+    const { dispatch, mapState } = this.props;
+    dispatch(setPointLocation(mapState.center))
   }
 
   render() {

--- a/www/js/components/add-point-location.js
+++ b/www/js/components/add-point-location.js
@@ -29,7 +29,6 @@ export class AddPointLocation extends Component {
   }
 
   componentDidMount() {
-    console.log("MOUNTING");
     const { dispatch, mapState } = this.props;
     dispatch(setPointLocation(mapState.center))
   }


### PR DESCRIPTION
Fixes #79 
  
Basically, you can go to the Name page directly after visiting the location page, and it will load the center of the map.